### PR TITLE
Upgrade to Django 1.9

### DIFF
--- a/{{cookiecutter.repo_name}}/django/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/django/requirements/base.txt
@@ -1,5 +1,5 @@
 setuptools>=0.8
-Django==1.8
+Django==1.9
 coverage==3.7
 factory-boy==2.2.1
 Sphinx==1.2b3

--- a/{{cookiecutter.repo_name}}/django/{{cookiecutter.repo_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/django/{{cookiecutter.repo_name}}/settings/base.py
@@ -1,7 +1,6 @@
 import os
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     ('{{cookiecutter.author_name}}', '{{cookiecutter.email}}'),
@@ -110,10 +109,6 @@ ROOT_URLCONF = 'urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'wsgi.application'
-
-TEMPLATE_DIRS = (
-    os.path.join(BASE_PATH, 'templates'),
-)
 
 INSTALLED_APPS = (
     # django contribs


### PR DESCRIPTION
Upgrade to Django 1.9.

`TEMPLATE_DEBUG` is now inside `TEMPLATES >> OPTIONS`;
`TEMPLATE_DIRS ` is now inside `TEMPLATES >> DIRS`;